### PR TITLE
add some augmentations

### DIFF
--- a/src/augmentation.py
+++ b/src/augmentation.py
@@ -6,31 +6,137 @@ affine_seq = iaa.Sequential([
                [iaa.Fliplr(0.5),
                 iaa.Flipud(0.5),
                 iaa.Affine(rotate=(0, 360),
-                           translate_percent=(-0.1, 0.1)),
-                iaa.CropAndPad(percent=(-0.25, 0.25), pad_cval=0)
+                           translate_percent={"x": (-0.1, 0.1), "y":(-0.1, 0.1)}),
+                iaa.CropAndPad(percent=(-0.25, 0.25), pad_mode='reflect')
                 ]),
     # Deformations
-    iaa.PiecewiseAffine(scale=(0.00, 0.06))
+    iaa.Sometimes(0.3, iaa.PiecewiseAffine(scale=(0.02, 0.04))),
+    iaa.Sometimes(0.3, iaa.PerspectiveTransform(scale=(0.05, 0.10))),
 ], random_order=True)
 
 color_seq = iaa.Sequential([
     # Color
+    iaa.Sometimes(0.3, iaa.ContrastNormalization((0.3, 1.0))),
+    iaa.Sometimes(0.3, iaa.ElasticTransformation(alpha=(1,5), sigma=0.1)),
     iaa.OneOf([
+        iaa.Noop(),
         iaa.Sequential([
-            iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
-            iaa.WithChannels(0, iaa.Add((0, 100))),
-            iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
-        iaa.Sequential([
-            iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
-            iaa.WithChannels(1, iaa.Add((0, 100))),
-            iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
-        iaa.Sequential([
-            iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
-            iaa.WithChannels(2, iaa.Add((0, 100))),
-            iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
-        iaa.WithChannels(0, iaa.Add((0, 100))),
-        iaa.WithChannels(1, iaa.Add((0, 100))),
-        iaa.WithChannels(2, iaa.Add((0, 100)))
+            iaa.OneOf([
+                iaa.OneOf([
+                    #Add in HSV or RGB
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(0, iaa.Add((0, 100))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(1, iaa.Add((0, 100))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(2, iaa.Add((0, 100))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.WithChannels(0, iaa.Add((0, 100))),
+                    iaa.WithChannels(1, iaa.Add((0, 100))),
+                    iaa.WithChannels(2, iaa.Add((0, 100)))
+                ]),
+                iaa.OneOf([
+                    #Add elementwise in HSV or RGB
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(0, iaa.AddElementwise((0, 30))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(1, iaa.AddElementwise((0, 30))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(2, iaa.AddElementwise((0, 30))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.WithChannels(0, iaa.AddElementwise((0, 30))),
+                    iaa.WithChannels(1, iaa.AddElementwise((0, 30))),
+                    iaa.WithChannels(2, iaa.AddElementwise((0, 30)))
+                ]),
+                iaa.OneOf([
+                    #Multiply in HSV or RGB
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(0, iaa.Multiply((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(1, iaa.Multiply((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(2, iaa.Multiply((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.WithChannels(0, iaa.Multiply((0, 2))),
+                    iaa.WithChannels(1, iaa.Multiply((0, 2))),
+                    iaa.WithChannels(2, iaa.Multiply((0, 2)))
+                ]),
+                iaa.OneOf([
+                    #Multiply elementwise in HSV or RGB
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(0, iaa.MultiplyElementwise((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(1, iaa.MultiplyElementwise((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.Sequential([
+                        iaa.ChangeColorspace(from_colorspace="RGB", to_colorspace="HSV"),
+                        iaa.WithChannels(2, iaa.MultiplyElementwise((0, 2))),
+                        iaa.ChangeColorspace(from_colorspace="HSV", to_colorspace="RGB")]),
+                    iaa.WithChannels(0, iaa.MultiplyElementwise((0, 2))),
+                    iaa.WithChannels(1, iaa.MultiplyElementwise((0, 2))),
+                    iaa.WithChannels(2, iaa.MultiplyElementwise((0, 2)))
+                ]),
+            ]),
+            iaa.OneOf([
+                iaa.Noop(),
+                iaa.CoarseSaltAndPepper(p=(0, 0.1), size_px=(64, 1024), per_channel=True),
+                iaa.CoarseSaltAndPepper(p=(0, 0.1), size_px=(64, 1024), per_channel=False)
+            ])
+        ]),
+        iaa.OneOf([
+            iaa.GaussianBlur(sigma=(0.4, 8.0)),
+            iaa.AverageBlur(k=(2, 21)),
+            iaa.MedianBlur(k=(3, 15))
+        ]),
+        iaa.OneOf([
+            iaa.Sharpen(alpha=0.5),
+            iaa.Emboss(alpha=(0.0, 1.0), strength=(0.5, 1.5))
+        ])
     ])
-], random_order=True)
+], random_order=False)
+
+color_seq_grey = iaa.Sequential([
+    # Color
+    iaa.Invert(0.3),
+    iaa.Sometimes(0.3, iaa.ContrastNormalization((0.5, 1.5))),
+    iaa.Sometimes(0.3, iaa.ElasticTransformation(alpha=(1,5), sigma=0.1)),
+    iaa.OneOf([
+        iaa.Noop(),
+        iaa.Sequential([
+            iaa.OneOf([
+                iaa.Add((0, 100)),
+                iaa.AddElementwise((0, 100)),
+                iaa.Multiply((0, 100)),
+                iaa.MultiplyElementwise((0, 100)),
+            ]),
+            iaa.OneOf([
+                iaa.Noop(),
+                iaa.CoarseSaltAndPepper(p=(0, 0.1), size_px=(64, 1024), per_channel=False)
+            ])
+        ]),
+        iaa.OneOf([
+            iaa.GaussianBlur(sigma=(0.0, 8.0)),
+            iaa.AverageBlur(k=(2, 21)),
+            iaa.MedianBlur(k=(3, 15))
+        ])
+    ])
+], random_order=False)
 


### PR DESCRIPTION
Current augmentations:
* Sharpen, Emboss
* Gaussian Blur, Median Blur, Average Blur
* Contrast normalization
* rotates and flips
* Elastic Transform, Perspective Transform, Piecewise Affine transforms
* Random adding/multiplying channels in rgb or hsv (also elementwise, currently not gaussian)

Still need to be added:
* Clahe,
* Gaussian Noise (still needed?)
* Color to Gray
* Inverting - we should not have used it, some images were not predicted correctly on stage2 because of this augmentation (That's why it is not included)
* Remapping grayscale images to random color images
 * Motion Blur
*  contrast and brightness (does the first mean contrast normalization?)
*  random scale, 
*  pincushion distortion
*  Random HSV (What's that?)
*  Channel shuffle
*  Nucleus copying on images. That created a lot of overlapping nuclei. It seemed to help networks to learn better borders for overlapping nuclei.
